### PR TITLE
fix: fix evaluation of early-stopping criterion

### DIFF
--- a/training/trainer.py
+++ b/training/trainer.py
@@ -79,6 +79,7 @@ class TrainerAdam(object):
 
                     net.train(True)  # set model to training mode (important for batch-norm/dropout)
                     if self.should_save_early_stop_checkpoint(val_loss_hist[hist_count], min_val_loss):
+                        min_val_loss = val_loss_hist[hist_count]
                         early_stop_index = j
                         early_stop_checkpoint = deepcopy(net.state_dict())
                     hist_count += 1


### PR DESCRIPTION
Fix the evaluation of the early-stopping criterion during training. So far the upper bound for the validation loss has never been updated, thus all `EarlyStopHistory` objects contained checkpoints and indices from the end of training. The test routine for the training process has been improved to detect such bugs.

Impact of this bug:

- As the early-stopping criterion has always been applied retroactively to create plots, the IMP and OSP experiments are absolutely valid. Additionally both use one network during training and do not load any models from histories, and pruning is always performed in the end of training, anyway.
- RandomRetrain experiments do load models from `EarlyStopHistory` objects to randomly reinitialize and train them, but the important part is the state of the pruned masks, which does not change at all during training. This is why these experiments are also valid.
- Visualizations are not correct, if the state at early-stopping should be shown. However they show the state at the end of training. Those experiments need to be repeated.